### PR TITLE
Update io-package.json

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -20,7 +20,7 @@
     },
     "native": {
         "webserverEnabled": true,
-        "webserverPort":    8083,
+        "webserverPort":    8080,
         "elapsedInterval":  2000,
         "devices": [
             {"name": "Sonos1", "ip" : "0.0.0.0", "room": ""}


### PR DESCRIPTION
Wenn man den Adapter im Default mit Port 8083 installiert, funktioniert die Sonos-Steuerung per Webseite nicht.
Bei der Standardinstallation des Web- und des Sonos-Adapters, funktioniert es mit Port 8080.