### PR TITLE
fixed overflowed labels in materialize

### DIFF
--- a/admin/index_m.html
+++ b/admin/index_m.html
@@ -127,27 +127,27 @@
             <div class="row">
                 <div class="input-field col s12 m4">
                     <input  class="value" id="webserverEnabled" type="checkbox"/>
-                    <span class="translate" for="webserverEnabled">Web server:</span>
+                    <span class="translate active" for="webserverEnabled">Web server:</span>
                 </div>
                 <div class="input-field col s12 m4">
                     <input  class="value" type="number" id="webserverPort" min="1" max="65535"/>
-                    <label class="translate" for="webserverPort">Port:</label>
+                    <label class="translate active" for="webserverPort">Port:</label>
                 </div>
             </div>
             <div class="row">
                 <div class="input-field col s12 m4">
                     <input  class="value" type="number" id="elapsedInterval" min="500" max="60000"/>
-                    <label class="translate" for="elapsedInterval">Update of elapsed time(ms):</label>
+                    <label class="translate active" for="elapsedInterval">Update of elapsed time(ms):</label>
                 </div>
             </div>
             <div class="row">
                 <div class="input-field col s12 m4">
                     <input  class="value" type="number" id="fadeIn" min="0" max="10000"/>
-                    <label class="translate" for="fadeIn">Fade in (text2speech)(ms):</label>
+                    <label class="translate active" for="fadeIn">Fade in (text2speech)(ms):</label>
                 </div>
                 <div class="input-field col s12 m4">
                     <input  class="value" type="number" id="fadeOut" min="0" max="10000"/>
-                    <label class="translate" for="fadeOut">Fade out (text2speech)(ms):</label>
+                    <label class="translate active" for="fadeOut">Fade out (text2speech)(ms):</label>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixed a problem where the labels appear in the foreground of the edits in materialze. 