### PR TITLE
Added state favorites_list_Array

### DIFF
--- a/main.js
+++ b/main.js
@@ -553,7 +553,7 @@ function createChannel(name, ip, room, callback) {
             desc:   'List of favorites song or stations, divided by comma',
             name:   'Favorites list'
         },
-        'favorites_list_Array': {    // media.favorites.array -   list of favorite channels in JSON format (read only)
+        'favorites_list_array': {    // media.favorites.array -   list of favorite channels in JSON format (read only)
             def:    '',
             type:   'object',
             read:   true,
@@ -1364,7 +1364,7 @@ function takeSonosFavorites(ip, favorites) {
     }
 
     adapter.setState({device: 'root', channel: ip, state: 'favorites_list'}, {val: sFavorites, ack: true});
-    adapter.setState({device: 'root', channel: ip, state: 'favorites_list_Array'}, {val: aFavorites, ack: true});
+    adapter.setState({device: 'root', channel: ip, state: 'favorites_list_array'}, {val: aFavorites, ack: true});
 }
 
 function getIp(player, noReplace) {

--- a/main.js
+++ b/main.js
@@ -553,6 +553,15 @@ function createChannel(name, ip, room, callback) {
             desc:   'List of favorites song or stations, divided by comma',
             name:   'Favorites list'
         },
+        'favorites_list_Array': {    // media.favorites.array -   list of favorite channels in JSON format (read only)
+            def:    '',
+            type:   'object',
+            read:   true,
+            write:  false,
+            role:   'media.favorites.array',
+            desc:   'Array of favorites song or stations',
+            name:   'Favorites Array'
+        },
         'favorites_set': {     // media.favorites.set -    select favorites from list (write only)
             def:    '',
             type:   'string',
@@ -1344,14 +1353,18 @@ function readCoverFileToState(fileName, stateName, ip) {
 
 function takeSonosFavorites(ip, favorites) {
     let sFavorites = '';
-    for (const favorite in favorites) {
+	let aFavorites = [];
+
+	for (const favorite in favorites) {
         if (!favorites.hasOwnProperty(favorite)) continue;
         if (favorites[favorite].title) {
             sFavorites += ((sFavorites) ? ', ' : '') + favorites[favorite].title;
+			aFavorites.push(favorites[favorite].title);
         }
     }
 
     adapter.setState({device: 'root', channel: ip, state: 'favorites_list'}, {val: sFavorites, ack: true});
+    adapter.setState({device: 'root', channel: ip, state: 'favorites_list_Array'}, {val: aFavorites, ack: true});
 }
 
 function getIp(player, noReplace) {


### PR DESCRIPTION
Added new state 'favorites_list_Array', containing the array of all favorites. Reason: State 'favorites_list' is a comma separated list, which has issues if a favorite name contains comma. 
Therefore, adding an additional state 'favorites_list_Array' to provide an array of the favorites list, it will also allow comma within the favorite names. Therefore, I am suggesting to also add an array of the favorites as state. 
Please bear with me, this is my first commit to a code change of an adapter :-) 
I am also not sure if 'favorites_list_Array' is the correct nomenclature for state names moving forward, probably favoritesListArray would be better, but wanted to keep the adapter's name convention somehow.