### PR TITLE
implemented url (http/https) support for specifying tts/mp3 files which

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -1,8 +1,12 @@
 {
     "common": {
         "name": "sonos",
-        "version": "2.0.1",
+        "version": "2.0.2",
         "news": {
+            "2.0.2": {
+                "en": "implemented direct http/https TTS support",
+                "de": "direkte Unterstützung für http/https tts support hinzugefügt"
+             },
             "2.0.1": {
                 "en": "create sonos cache directory",
                 "de": "Erstellen Sie ein Sonos-Cache-Verzeichnis",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "iobroker.sonos",
   "description": "The adapter lets control SONOS from ioBroker",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "engines": {
     "node": ">=4.0.0"
   },
   "contributors": [
-    "bluefox <dogafox@gmail.com>"
+    "bluefox <dogafox@gmail.com>",
+    "Jens Maus <mail@jens-maus.de>"
   ],
   "author": "bluefox <dogafox@gmail.com>",
   "homepage": "https://github.com/ioBroker/ioBroker.sonos",


### PR DESCRIPTION
in fact, e.g. the sayit adapter provides after having converted text to
speech. Previously, the "tts" datapoint only allowed to specify a local
filename, but now a user can supply an http/https url from which each
sonos box can directly download+play the converted mp3.
This refs #38, #35, #24.