### PR TITLE
feat: adds support for playing Sonos playlists

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Control and monitor SONOS devices with ioBroker.
    * **`group_muted`**: mute status of the group.
    * **`add_to_group`**: Add a certain SONOS device to the SONOS device under which this state is. Use IP address with underscores (see above).
    * **`remove_from_group`**: Remove a certain SONOS device from the SONOS device under which this state is. Use IP address with underscores (see above).
-   
+
 *) These states will be updated if changes are made in the SONOS app.
 
 ## Using with the sayIt adapter
@@ -112,6 +112,9 @@ Please note: highlighting current playing favorite is not supported.
 	### **WORK IN PROGRESS**
 -->
 ## Changelog
+### **WORK IN PROGRESS**
+* (udondan) adds support for playing Sonos playlists (new state `playlist_set`)
+
 ### 2.3.3 (2023-09-21)
 * (foxriver76) fixed cover url
 

--- a/main.js
+++ b/main.js
@@ -200,6 +200,25 @@ function startAdapter(options) {
                             );
                         })
                         .catch(error => adapter.log.error('Cannot replaceWithFavorite: ' + error));
+                    } else if (id.state === 'playlist_set') {
+                    promise = player
+                        .replaceWithPlaylist(state.val)
+                        .then(() => player.play())
+                        .then(() => {
+                            adapter.setState(
+                                { device: 'root', channel: id.channel, state: 'current_album' },
+                                { val: state.val, ack: true }
+                            );
+                            adapter.setState(
+                                {
+                                    device: 'root',
+                                    channel: id.channel,
+                                    state: 'current_artist'
+                                },
+                                { val: state.val, ack: true }
+                            );
+                        })
+                        .catch(error => adapter.log.error('Cannot replaceWithPlaylist: ' + error));
                 } else if (id.state === 'tts') {
                     adapter.log.debug(`Play TTS file ${state.val} on ${id.channel}`);
                     text2speech(state.val, id.channel);
@@ -485,6 +504,16 @@ const newGroupStates = {
         write: false,
         role: 'indicator.members',
         desc: 'Group members Channels'
+    },
+    playlist_set: {
+        // media.playlist.set -    select Sonos playlist (write only)
+        def:    '',
+        type:   'string',
+        read:   false,
+        write:  true,
+        role:   'media.playlist.set',
+        desc:   'Set Sonos playlist to play',
+        name:   'Playlist set'
     }
 };
 


### PR DESCRIPTION
This adds support for playing native Sonos playlists. Technically pretty much the same as `favorites_set`. I'm currently running this code on my ioBroker.

fixes #165