### PR TITLE
added bass and treble control 

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Please note: highlighting current playing favorite is not supported.
 	### **WORK IN PROGRESS**
 -->
 ## Changelog
+
+### WORK IN PROGRESS
+
+(seb2010) Added support to control bass and treble of a player (NO updates of these states on external events!)
+
 ### 3.0.0 (2023-10-09)
 * (udondan) Added support for the playing Sonos playlists (added new state `playlist_set`)
 * (bluefox) The minimal node.js version is 16

--- a/main.js
+++ b/main.js
@@ -148,6 +148,10 @@ function startAdapter(options) {
                     }
                 } else if (id.state === 'volume') {
                     promise = player.setVolume(state.val);
+                } else if (id.state === 'treble') {
+                    promise = player.setTreble(state.val);
+                } else if (id.state === 'bass') {
+                    promise = player.setBass(state.val);
                 } else if (id.state === 'state') {
                     //stop,play,pause,next,previous,mute,unmute
                     if (state.val && typeof state.val === 'string') {
@@ -607,6 +611,28 @@ async function createChannel(name, ip, room) {
             max: 100,
             desc: 'State and control of volume',
             name: 'Player volume'
+        },
+        treble: {
+            // level.treble -           treble level (read, write)
+            type: 'number',
+            read: true,
+            write: true,
+            role: 'level.treble',
+            min: -10,
+            max: 10,
+            desc: 'State and control of treble',
+            name: 'Player treble'
+        },
+        bass: {
+            // level.bass -           bass level (read, write)
+            type: 'number',
+            read: true,
+            write: true,
+            role: 'level.bass',
+            min: -10,
+            max: 10,
+            desc: 'State and control of bass',
+            name: 'Player bass'
         },
         muted: {
             // media.muted -            is muted (read only)
@@ -1780,6 +1806,12 @@ function processSonosEvents(event, data) {
                 adapter.log.debug(`volume: Volume for ${player.baseUrl}: ${data.newVolume}`);
             }
         }
+    } else if (event === 'treble') {
+        // node-sonos-discovery is not emitting any events on treble changes yet, so it is not
+        // possible to get the externally set treble value, yet. 
+    } else if (event === 'bass') {
+        // node-sonos-discovery is not emitting any events on bass changes yet, so it is not
+        // possible to get the externally set bass value, yet. 
     } else if (event === 'mute') {
         // {
         //     uuid:        _this.uuid,

--- a/main.js
+++ b/main.js
@@ -613,9 +613,9 @@ async function createChannel(name, ip, room) {
             name: 'Player volume'
         },
         treble: {
-            // level.treble -           treble level (read, write)
+            // level.treble -           treble level (only write)
             type: 'number',
-            read: true,
+            read: false,
             write: true,
             role: 'level.treble',
             min: -10,
@@ -624,9 +624,9 @@ async function createChannel(name, ip, room) {
             name: 'Player treble'
         },
         bass: {
-            // level.bass -           bass level (read, write)
+            // level.bass -           bass level (only write)
             type: 'number',
-            read: true,
+            read: false,
             write: true,
             role: 'level.bass',
             min: -10,


### PR DESCRIPTION
Two modifications were done:
1. added the "bass" and "treble" states to the channel (r/w, -10 / +10 range)
2. added statechange reaction for calling the setBass and setTreble function accordingly

As the node-sonos-discovery library does not seem to emit any events when the bass and/or treble value is changes externally, there is no point to listen for these changes. So you will ONLY be able to set new bass and trebles values but you cannot use the states to read the current bass and treble setting, as it will not get updated properly on external changes