### PR TITLE
fix: recreate missing states for existing channels in syncConfig

### DIFF
--- a/main.js
+++ b/main.js
@@ -2025,6 +2025,8 @@ async function syncConfig() {
                             elapsed: 0,
                             obj: _channels[j]
                         };
+                        const _dev = adapter.config.devices.find(d => d.ip === ip);
+                        await createChannel(_dev?.name || ip, ip, _dev?.room);
                         await adapter.setStateAsync(`root.${sId}.alive`, false, true);
                         aliveIds.push(`root.${sId}.alive`);
                     } else {


### PR DESCRIPTION
## Problem

When a channel object (root node) exists but its child states are missing — e.g. after manual deletion or a previous bug — `syncConfig()` sets `alive = false` directly without first creating the states. This causes repeated warnings on every adapter start:

```
State "sonos.0.root.10_2_1_xxx.alive" has no existing object, this might lead to an error in future versions
State "sonos.0.root.10_2_1_xxx.volume" has no existing object, this might lead to an error in future versions
... (all states)
```

## Root cause

In `syncConfig()`, when a channel is found in both the existing objects and the config (`pos !== -1`), the code assumes the channel is fully intact and goes straight to `setStateAsync`. It does not verify that the child states actually exist.

## Fix

Call `createChannel()` before `setStateAsync()`. Since `createChannel` uses `createStateAsync` internally, it is idempotent — existing states are left unchanged, missing ones are recreated.

## Tested

Reproduced on a Sonos Port where the states had been deleted. After this fix, the adapter recreates all states cleanly on start and the warnings are gone.